### PR TITLE
remove food input step

### DIFF
--- a/src/views/food/subForms/FoodConsumption.vue
+++ b/src/views/food/subForms/FoodConsumption.vue
@@ -206,7 +206,6 @@
         inputDescription="plantBasedDrinksDescription"
         maxValue="20"
         unit="l/ "
-        step="0.1"
         v-model.number="plantBasedDrinks"
       ></FoodConsumptionInput>
     </div>
@@ -219,7 +218,6 @@
         inputName="coffeeAndTea"
         maxValue="20"
         unit="l/ "
-        step="0.1"
         v-model.number="coffeeAndTea"
       ></FoodConsumptionInput>
 
@@ -227,7 +225,6 @@
         inputName="alcoholicBeverages"
         maxValue="10"
         unit="l/ "
-        step="0.1"
         v-model.number="alcoholicBeverages"
       ></FoodConsumptionInput>
 
@@ -236,7 +233,6 @@
         inputDescription="otherDrinksDescription"
         maxValue="20"
         unit="l/ "
-        step="0.1"
         v-model.number="otherDrinks"
       ></FoodConsumptionInput>
     </div>

--- a/src/views/food/subForms/FoodConsumption.vue
+++ b/src/views/food/subForms/FoodConsumption.vue
@@ -92,7 +92,6 @@
         inputName="milk"
         maxValue="20"
         unit="l/ "
-        step="0.1"
         v-model.number="milk"
       ></FoodConsumptionInput>
 
@@ -120,7 +119,6 @@
         inputName="eggs"
         maxValue="100"
         unit="$piecesShort"
-        step="1"
         v-model.number="eggsCount"
       ></FoodConsumptionInput>
     </div>

--- a/src/views/food/subForms/FoodConsumptionInput.vue
+++ b/src/views/food/subForms/FoodConsumptionInput.vue
@@ -52,7 +52,7 @@ const props = defineProps({
     type: String,
     required: false,
     default: 'g/ ',
-  }
+  },
 })
 </script>
 

--- a/src/views/food/subForms/FoodConsumptionInput.vue
+++ b/src/views/food/subForms/FoodConsumptionInput.vue
@@ -10,7 +10,6 @@
       :id="props.inputName"
       type="range"
       min="0"
-      :step="props.step"
       :max="maxValue"
       v-model="model"
     />
@@ -19,7 +18,6 @@
         :id="props.inputName"
         type="number"
         min="0"
-        :step="props.step"
         :max="props.maxValue"
         v-model.number="model"
       />
@@ -54,12 +52,7 @@ const props = defineProps({
     type: String,
     required: false,
     default: 'g/ ',
-  },
-  step: {
-    type: String,
-    required: false,
-    default: '10',
-  },
+  }
 })
 </script>
 


### PR DESCRIPTION
Since these can cause native validation errors (e.g. input 3 into one where the step is 10 and submit), and these are shown in the browser language instead of the app language, remove these for now.

They only function to ease using the visual number inputs (arrows up/down) which no-one probably uses anyway, when the range is in the thousands