### PR TITLE
set default food input step to 1

### DIFF
--- a/src/views/food/subForms/FoodConsumption.vue
+++ b/src/views/food/subForms/FoodConsumption.vue
@@ -120,7 +120,6 @@
         inputName="eggs"
         maxValue="100"
         unit="$piecesShort"
-        step="1"
         v-model.number="eggsCount"
       ></FoodConsumptionInput>
     </div>

--- a/src/views/food/subForms/FoodConsumptionInput.vue
+++ b/src/views/food/subForms/FoodConsumptionInput.vue
@@ -58,7 +58,7 @@ const props = defineProps({
   step: {
     type: String,
     required: false,
-    default: '10',
+    default: '1',
   },
 })
 </script>


### PR DESCRIPTION
Since these can cause native validation errors (e.g. input 3 into one where the step is 10 and submit), and these are shown in the browser language instead of the app language, set the default to 1 so as not to limit the range of valid inputs.

They only function to ease using the visual number inputs (arrows up/down) which no-one probably uses anyway, when the range is in the thousands
